### PR TITLE
Remover quebras de linha no local do BO.

### DIFF
--- a/src/main/java/br/com/ivansalvadori/ssp/sp/cleaner/BoletimOcorrenciasExtractor.java
+++ b/src/main/java/br/com/ivansalvadori/ssp/sp/cleaner/BoletimOcorrenciasExtractor.java
@@ -113,7 +113,9 @@ public class BoletimOcorrenciasExtractor {
 						StringBuilder local = new StringBuilder(iteratorDetalhes.next().html());
 						local.append(" - ");
 						local.append(iteratorDetalhes.next().html());
-						boletimOcorrencia.setLocal(local.toString());
+						String localString = local.toString()
+								.replaceAll("\n", " - ").replaceAll("<br>", "");
+						boletimOcorrencia.setLocal(localString);
 					}
 					if (textoDetalhe.equalsIgnoreCase("Tipo de Local:")) {
 						StringBuilder tipoLocal = new StringBuilder(iteratorDetalhes.next().html());


### PR DESCRIPTION
BO em 2014-HomicidioDoloso-RawData/BOs/30117-2310.html possuía quebra de linha no local. Por consequência boletins.csv era gerado com uma linha inconsistente. "\n" é substituído por " - " e "&lt;br&gt;" por "".
