### PR TITLE
Sanitização da nacionalidade das partes envolvidas.

### DIFF
--- a/src/main/java/br/com/ivansalvadori/ssp/sp/cleaner/BoletimOcorrenciasExtractor.java
+++ b/src/main/java/br/com/ivansalvadori/ssp/sp/cleaner/BoletimOcorrenciasExtractor.java
@@ -23,7 +23,7 @@ import com.google.gson.GsonBuilder;
 
 @Component
 public class BoletimOcorrenciasExtractor {
-
+	private NacionalidadeSanitizer nacionalidadeSanitizer = new NacionalidadeSanitizer();
 	private List<BoletimOcorrencia> boletinsProcessados = new ArrayList<>();
 
 	public void parseDocument(String folderPathInput, String folderPathOutput) throws IOException {
@@ -233,7 +233,9 @@ public class BoletimOcorrenciasExtractor {
 				} else if (fragmento.startsWith("Natural de:")) {
 					parteEnvolvida.setNaturalidade(fragmento.replace("Natural de:", "").trim());
 				} else if (fragmento.startsWith("Nacionalidade:")) {
-					parteEnvolvida.setNacionalidade(fragmento.replace("Nacionalidade:", "").trim());
+					String nacionalidade = fragmento.replace("Nacionalidade:", "").trim();
+					nacionalidade = nacionalidadeSanitizer.sanitize(nacionalidade);
+					parteEnvolvida.setNacionalidade(nacionalidade);
 				} else if (fragmento.startsWith("Sexo:")) {
 
 					String sexo = fragmento.replace("Sexo:", "").trim();

--- a/src/main/java/br/com/ivansalvadori/ssp/sp/cleaner/NacionalidadeSanitizer.java
+++ b/src/main/java/br/com/ivansalvadori/ssp/sp/cleaner/NacionalidadeSanitizer.java
@@ -1,0 +1,88 @@
+package br.com.ivansalvadori.ssp.sp.cleaner;
+
+import au.com.bytecode.opencsv.CSVReader;
+import com.google.gson.Gson;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class NacionalidadeSanitizer {
+    private HashMap<String, HashSet<String>> keywords = new HashMap<>();
+    private HashMap<String, HashSet<Pattern>> regexps = new HashMap<>();
+
+    private static class RegexpMap {
+        public static class RegexSpec {
+            public String nacionalidade;
+            public String[] regexps;
+        }
+        public RegexSpec[] specs;
+    }
+
+
+    public NacionalidadeSanitizer() {
+        keywords.put("BRASILEIRA", keywordsBrasileira());
+        for (RegexpMap.RegexSpec spec : loadRegExps().specs) {
+            HashSet<Pattern> set = new HashSet<>();
+            for (String string : spec.regexps) set.add(Pattern.compile(string));
+            regexps.put(spec.nacionalidade, set);
+        }
+    }
+
+    private RegexpMap loadRegExps() {
+        ClassLoader loader = NacionalidadeSanitizer.class.getClassLoader();
+        InputStream stream = loader.getResourceAsStream("nacionalidade-regexps.json");
+        InputStreamReader reader = new InputStreamReader(stream, Charset.forName("UTF-8"));
+        return new Gson().fromJson(reader, RegexpMap.class);
+    }
+
+    private HashSet<String> keywordsBrasileira() {
+        HashSet<String> set = new HashSet<>();
+        ClassLoader loader = NacionalidadeSanitizer.class.getClassLoader();
+        InputStream stream = loader.getResourceAsStream("estados.csv");
+        InputStreamReader reader = new InputStreamReader(stream, Charset.forName("UTF-8"));
+        CSVReader csvReader = new CSVReader(reader, ',');
+        try {
+            for (String[] line : csvReader.readAll()) {
+                for (String kw : line) set.add(kw.toUpperCase());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("IOException while reading from resource.", e);
+        }
+
+        return set;
+    }
+
+    public String sanitize(String nacionalidade) {
+        nacionalidade = nacionalidade.trim();
+        nacionalidade = nacionalidade.toUpperCase();
+        nacionalidade = removeRepeatedLetters(nacionalidade);
+
+        for (Map.Entry<String, HashSet<Pattern>> entry : regexps.entrySet()) {
+            for (Pattern pattern : entry.getValue()) {
+                if (pattern.matcher(nacionalidade).matches())
+                    return entry.getKey();
+            }
+        }
+        for (Map.Entry<String, HashSet<String>> entry : keywords.entrySet()) {
+            for (String kw : entry.getValue()) {
+                if (nacionalidade.equals(kw))
+                    return entry.getKey();
+            }
+        }
+
+        return nacionalidade;
+    }
+
+    private String removeRepeatedLetters(String nacionalidade) {
+        String old = nacionalidade;
+        do {
+            old = nacionalidade;
+            nacionalidade = nacionalidade.replaceAll("([^SR])\\1", "$1");
+        } while (!old.equals(nacionalidade));
+        return nacionalidade;
+    }
+}

--- a/src/main/resources/estados.csv
+++ b/src/main/resources/estados.csv
@@ -1,0 +1,28 @@
+sigla,estado,gentilico,gentilico2
+AC,Acre,acriano,acreano
+AL,Alagoas,alagoano
+AP,Amapá,amapaense
+AM,Amazonas,amazonense
+BA,Bahia,baiano
+CE,Ceará,cearense
+DF,Distrito Federal,brasiliense
+ES,Espírito Santo,capixaba,espírito-santense
+GO,Goiás,goiano
+MA,Maranhão,maranhense
+MT,Mato Grosso,mato-grossense
+MS,Mato Grosso do Sul,sul-mato-grossense
+MG,Minas Gerais,mineiro
+PA,Pará,paraense
+PB,Paraíba,paraibano
+PR,Paraná,paranaense
+PE,Pernambuco,pernambucano
+PI,Piauí,piauiense
+RJ,Rio de Janeiro,fluminense
+RN,Rio Grande do Norte,potiguar,norte-rio-grandense
+RS,Rio Grande do Sul,gaúcho,sul-rio-grandense
+RO,Rondônia,rondoniano,rondoniense
+RR,Roraima,roraimense
+SC,Santa Catarina,catarinense,barriga-verde
+SP,São Paulo,paulista
+SE,Sergipe,sergipano
+TO,Tocantins,tocantinense

--- a/src/main/resources/nacionalidade-regexps.json
+++ b/src/main/resources/nacionalidade-regexps.json
@@ -1,0 +1,8 @@
+{
+  "specs" : [
+    {
+      "nacionalidade" : "BRASILEIRA",
+      "regexps" : [ "^BR(?:A.*|\\.?)$" ]
+    }
+  ]
+}


### PR DESCRIPTION
NacionalidadeSanitizer remove alguns erros comuns no campo nacionalidade das partes envolvidas.
- Letras repetidas (exceto R e S) são eliminadas
- Estados e gentílicos estaduais são convertidos para "BRASILEIRA"
- Expressões regulares são aplicadas para amenizar diferentes grafias das nacionalidades.

A lista de estados e gentílicos foi obtida de https://www12.senado.leg.br/manualdecomunicacao/redacao-e-estilo/estilo/adjetivos-gentilicos/adjetivos-gentilicos-das-capitais-brasileiras, e está em formato csv em estados.csv.

As expressões regulares podem ser adicionadas em nacionalidade-regexps.json
